### PR TITLE
Ensure open() works even if tiger.pomdp does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note that you can generate `.pomdp` files using [`POMDPFiles.jl`](https://github
 ```julia
 using POMDPFiles
 using POMDPModels
-fout = open("tiger.pomdp")
+fout = open("tiger.pomdp", "w")
 write(fout, TigerPOMDP())
 close(fout)
 pomdp = POMDPSolveFile("tiger.pomdp")


### PR DESCRIPTION
I added the "w" argument, because in a fresh installation (depending on your path) the "tiger.pomdp" file will not exist. At least it didn't when I tried this in my setup so adding the "w" argument would prevent Julia newbies to try to figure out why the open("tiger.pomdp") does not work.